### PR TITLE
日志精细化整改

### DIFF
--- a/cmd/ctrl/app/utils.go
+++ b/cmd/ctrl/app/utils.go
@@ -15,12 +15,11 @@ func WithSignalCatch(root context.Context) context.Context {
 	signal.Reset(syscall.SIGTERM, syscall.SIGINT)
 	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
-		// Listen for OS signals and call cancel() when received
 		<-ch
-		klog.Infof("Received shutdown signal, initiating graceful shutdown...")
+		klog.Warning("[Signal] graceful shutdown in progress...")
 		cancel()
 		<-ch
-		klog.Infof("Received second shutdown signal, forcing exit...")
+		klog.Warning("[Signal] received second shutdown signal, forcing exit...")
 		os.Exit(1)
 	}()
 	return ctx

--- a/internal/cli/proxy/http_transport.go
+++ b/internal/cli/proxy/http_transport.go
@@ -20,7 +20,7 @@ type httpTransport struct {
 
 func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	svrHost, svrPort, isService := parseHost(req.Host)
-	klog.Infof("Proxy: Received request for host: %s (service: %s, port: %s, isService: %v)",
+	klog.V(4).Infof("[Proxy] received request for host: %s (service: %s, port: %s, isService: %v)",
 		req.Host, svrHost, svrPort, isService)
 
 	// IP-based requests always pass through
@@ -53,7 +53,7 @@ func (t *httpTransport) passThrough(req *http.Request, logFormat string, args ..
 	if req.URL.Host == "" {
 		req.URL.Host = req.Host
 	}
-	klog.Infof("Proxy: "+logFormat, args...)
+	klog.V(4).Infof("[Proxy] "+logFormat, args...)
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -64,18 +64,18 @@ func (t *httpTransport) loadBalance(req *http.Request, service, port string, rul
 	}
 
 	endpoints := t.getEndpoints(service)
-	klog.Infof("Proxy: Load balancing across %d endpoints for service %s", len(endpoints), service)
+	klog.V(4).Infof("[Proxy] load balancing across %d endpoints for service %s", len(endpoints), service)
 
 	for _, endpoint := range endpoints {
 		// Check circuit breaker
 		if rule.UseBreaker && t.listener.breaker != nil {
 			if !t.listener.breaker.Allowed(endpoint) {
-				klog.Warningf("Proxy: Endpoint %s circuit broken, skipping", endpoint)
+				klog.Warningf("[Proxy] endpoint %s circuit broken, skipping", endpoint)
 				continue
 			}
 		}
 
-		klog.Infof("Proxy: Trying endpoint %s:%s", endpoint, port)
+		klog.V(4).Infof("[Proxy] trying endpoint %s:%s", endpoint, port)
 		resp, err := t.sendRequest(req, body, endpoint, port)
 
 		// Record result in circuit breaker
@@ -91,7 +91,7 @@ func (t *httpTransport) loadBalance(req *http.Request, service, port string, rul
 			continue
 		}
 
-		klog.Infof("Proxy: Successfully proxied to %s:%s", endpoint, port)
+		klog.V(4).Infof("[Proxy] successfully proxied to %s:%s", endpoint, port)
 		return resp, nil
 	}
 
@@ -111,7 +111,7 @@ func (t *httpTransport) sendRequest(req *http.Request, body []byte, ip, port str
 
 	resp, err := http.DefaultClient.Do(reqCopy)
 	if err != nil {
-		klog.V(4).Infof("request to %s failed: %v", reqCopy.Host, err)
+		klog.V(4).Infof("[Proxy] request to %s failed: %v", reqCopy.Host, err)
 		return nil, err
 	}
 
@@ -128,13 +128,13 @@ func (t *httpTransport) recordFailure(endpoint string, err error) {
 	errStr := err.Error()
 	if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "deadline exceeded") {
 		t.listener.breaker.RecordTimeout(endpoint)
-		klog.Warningf("Proxy: Timeout for %s", endpoint)
+		klog.Warningf("[Proxy] timeout for endpoint %s", endpoint)
 	} else if strings.Contains(errStr, "connection refused") || strings.Contains(errStr, "network") {
 		t.listener.breaker.RecordNetworkFailure(endpoint)
-		klog.Warningf("Proxy: Network failure for %s", endpoint)
+		klog.Warningf("[Proxy] network failure for endpoint %s", endpoint)
 	} else {
 		t.listener.breaker.RecordBusinessFailure(endpoint)
-		klog.Warningf("Proxy: Business failure for %s", endpoint)
+		klog.Warningf("[Proxy] business failure for endpoint %s", endpoint)
 	}
 }
 

--- a/internal/cli/proxy/listener.go
+++ b/internal/cli/proxy/listener.go
@@ -45,7 +45,7 @@ func (l *Listener) Listen(ctx context.Context, address string) error {
 		_ = listener.Close()
 	}()
 
-	klog.Infof("Proxy listening on %s", address)
+	klog.Infof("[Proxy] listening on %s", address)
 
 	for {
 		conn, err := listener.Accept()
@@ -53,7 +53,7 @@ func (l *Listener) Listen(ctx context.Context, address string) error {
 			if ctx.Err() != nil {
 				return nil
 			}
-			klog.Errorf("accept connection failed: %+v", err)
+			klog.Errorf("[Proxy] accept connection failed: %+v", err)
 			continue
 		}
 		go l.handleConnection(ctx, conn)
@@ -73,7 +73,7 @@ func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
 }
 
 func (l *Listener) handleHTTP(_ context.Context, conn net.Conn, reader *bufio.Reader) {
-	klog.V(4).Info("Handling HTTP connection")
+	klog.V(4).Info("[Proxy] handling HTTP connection")
 
 	proxy := &httputil.ReverseProxy{
 		Transport: &httpTransport{
@@ -81,7 +81,7 @@ func (l *Listener) handleHTTP(_ context.Context, conn net.Conn, reader *bufio.Re
 		},
 		Director: func(req *http.Request) {},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			klog.Errorf("HTTP proxy error: %v", err)
+			klog.Errorf("[Proxy] HTTP proxy error: %v", err)
 			http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		},
 	}
@@ -98,17 +98,17 @@ func (l *Listener) handleHTTP(_ context.Context, conn net.Conn, reader *bufio.Re
 }
 
 func (l *Listener) handleTCP(ctx context.Context, conn net.Conn, reader *bufio.Reader) {
-	klog.V(4).Info("Handling TCP connection")
+	klog.V(4).Info("[Proxy] handling TCP connection")
 
 	originalDst, err := getOriginalDst(conn)
 	if err != nil {
-		klog.Errorf("get original destination failed: %+v", err)
+		klog.Errorf("[Proxy] get original destination failed: %+v", err)
 		return
 	}
 
 	targetConn, err := net.Dial("tcp", originalDst.String())
 	if err != nil {
-		klog.Errorf("dial to target %s failed: %+v", originalDst.String(), err)
+		klog.Errorf("[Proxy] dial to target %s failed: %+v", originalDst.String(), err)
 		return
 	}
 	defer targetConn.Close()
@@ -138,7 +138,7 @@ func (l *Listener) handleTCP(ctx context.Context, conn net.Conn, reader *bufio.R
 	go func() {
 		defer wg.Done()
 		if _, err := io.Copy(targetConn, wrappedConn); err != nil {
-			klog.V(4).Infof("copy from client to target failed: %+v", err)
+			klog.V(4).Infof("[Proxy] copy from client to target failed: %+v", err)
 		}
 		if tcpConn, ok := targetConn.(*net.TCPConn); ok {
 			tcpConn.CloseWrite()

--- a/internal/cli/proxy/server.go
+++ b/internal/cli/proxy/server.go
@@ -30,6 +30,6 @@ func NewProxy(meshClient *rpcclient.MeshClient, opts *Options) (*Proxy, error) {
 }
 
 func (p *Proxy) Run(ctx context.Context, opts *Options) error {
-	klog.Infof("Starting proxy on %s", opts.ListenAddress())
+	klog.Infof("[Proxy] starting on %s", opts.ListenAddress())
 	return p.listener.Listen(ctx, opts.ListenAddress())
 }

--- a/internal/cli/rpcclient/client.go
+++ b/internal/cli/rpcclient/client.go
@@ -12,7 +12,7 @@ import (
 func NewRpcClient(remote string) mesh.MeshCtrlClient {
 	c, err := grpc.NewClient(remote, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		klog.Error("Failed to create gRPC client: ", err)
+		klog.Errorf("[RpcClient] failed to create gRPC client: %v", err)
 		panic(err)
 	}
 	return mesh.NewMeshCtrlClient(c)
@@ -38,7 +38,7 @@ func NewMeshClient(serviceCache *ServiceCache, opts *Options) *MeshClient {
 func (c *MeshClient) Connect() {
 	grpcConn, err := grpc.NewClient(c.remote, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		klog.Error("Failed to create gRPC client: ", err)
+		klog.Errorf("[RpcClient] failed to create gRPC client: %v", err)
 		panic(err)
 	}
 	c.connection = grpcConn
@@ -59,27 +59,27 @@ func (c *MeshClient) Subscribe(ctx context.Context, serviceName string) error {
 	}
 	stream, err := c.grpcClient.Subscribe(ctx, subReq)
 	if err != nil {
-		klog.Error("Failed to subscribe to events: ", err)
+		klog.Errorf("[RpcClient] failed to subscribe to events: %v", err)
 		return err
 	}
 	go func() {
-		klog.Info("Subscribed to events successfully, waiting for events...")
+		klog.Infof("[RpcClient] subscribed to service %s, waiting for events...", serviceName)
 		for {
 			event, err := stream.Recv()
 			if err != nil {
-				klog.Error("Failed to receive event: ", err)
+				klog.Errorf("[RpcClient] failed to receive event for service %s: %v", serviceName, err)
 				return
 			}
-			klog.Infof("Received event: %+v\n", event)
+			klog.V(4).Infof("[RpcClient] received event for service %s: %+v", serviceName, event)
 			switch event.GetOpType() {
 			case mesh.OpType_ADDED:
-				klog.Info("Receive a service-add event\n")
+				klog.Infof("[RpcClient] [%s] service-add event", serviceName)
 				c.serviceCache.onAdd(serviceName, (*Endpoints)(event))
 			case mesh.OpType_MODIFIED:
-				klog.Info("Receive a service-modify event\n")
+				klog.Infof("[RpcClient] [%s] service-modify event", serviceName)
 				c.serviceCache.onUpdate(serviceName, (*Endpoints)(event))
 			case mesh.OpType_DELETED:
-				klog.Info("Receive a service-delete event\n")
+				klog.Infof("[RpcClient] [%s] service-delete event", serviceName)
 				c.serviceCache.onDelete(serviceName)
 			}
 		}

--- a/internal/cli/stgsvr/handlers.go
+++ b/internal/cli/stgsvr/handlers.go
@@ -71,7 +71,7 @@ func (s *Server) subscribe(parent context.Context, serviceName string) error {
 func (s *Server) unsubscribe(serviceName string) error {
 	cancel, existed := s.svcContext.GetCancel(serviceName)
 	if !existed {
-		klog.Errorf("service %v not found", serviceName)
+		klog.Warningf("[StgSvr] service %s not found", serviceName)
 		return fmt.Errorf("service %v not found", serviceName)
 	}
 	cancel()

--- a/internal/cli/stgsvr/server.go
+++ b/internal/cli/stgsvr/server.go
@@ -29,9 +29,9 @@ func (s *Server) Run(ctx context.Context, opts *Options) error {
 	listener := utils.NewListenerOrDie("tcp", opts.stgSvrAddress)
 	go func() {
 		<-ctx.Done()
-		klog.Info("Shutting down HTTP server...")
+		klog.Info("[StgSvr] shutting down HTTP server...")
 		if err := listener.Close(); err != nil {
-			klog.Errorf("Failed to close listener: %v\n", err)
+			klog.Errorf("[StgSvr] failed to close listener: %v", err)
 			return
 		}
 	}()

--- a/internal/ctrl/grpcserver/server.go
+++ b/internal/ctrl/grpcserver/server.go
@@ -44,12 +44,12 @@ func (s *GrpcServer) Subscribe(sr *mesh.SubscriptionRequest, sss grpc.ServerStre
 	serviceName := sr.ServiceName
 	sidecar := utils.NewSidecar(sr.SidecarId, serviceName)
 
-	klog.Infof("[GrpcServer][Subscribe] Sidecar %s subscribed to service %s\n", sr.SidecarId, serviceName)
+	klog.Infof("[GrpcServer][Subscribe] sidecar %s subscribed to service %s", sr.SidecarId, serviceName)
 
 	// 订阅时先把当前的 EndpointSlice 发给 sidecar，确保 sidecar 能尽快拿到数据
 	es, exist := s.listFn(serviceName)
 	if exist {
-		klog.Infof("[GrpcServer][Subscribe] Sending current EndpointSlice for service %s to sidecar %s\n", serviceName, sr.SidecarId)
+		klog.Infof("[GrpcServer][Subscribe] sending current EndpointSlice for service %s to sidecar %s", serviceName, sr.SidecarId)
 		sidecar.Informer(mesh.OpType_ADDED, es)
 	}
 
@@ -64,16 +64,16 @@ func (s *GrpcServer) Subscribe(sr *mesh.SubscriptionRequest, sss grpc.ServerStre
 		s.mtx.Lock()
 		delete(s.sidecars, sr.SidecarId)
 		s.mtx.Unlock()
-		klog.Infof("[GrpcServer][Subscribe] Sidecar %s unsubscribed from service %s\n", sr.SidecarId, serviceName)
+		klog.Infof("[GrpcServer][Subscribe] sidecar %s unsubscribed from service %s", sr.SidecarId, serviceName)
 	}()
 
 	receiver := sidecar.Receiver()
 	for event := range receiver {
 		if err := sss.Send(event); err != nil {
-			klog.Errorf("[GrpcServer][Subscribe] Failed to send event to sidecar %s for service %s: %v\n", sr.SidecarId, serviceName, err)
+			klog.Errorf("[GrpcServer][Subscribe] failed to send event to sidecar %s for service %s: %v", sr.SidecarId, serviceName, err)
 			return err
 		}
-		klog.Infof("[GrpcServer][Subscribe] Sent event to sidecar %s for service %s: %+v\n", sr.SidecarId, serviceName, event)
+		klog.V(4).Infof("[GrpcServer][Subscribe] sent event to sidecar %s for service %s: %+v", sr.SidecarId, serviceName, event)
 	}
 	return nil
 }

--- a/internal/ctrl/handlers/mutate_webhook.go
+++ b/internal/ctrl/handlers/mutate_webhook.go
@@ -14,13 +14,13 @@ import (
 // getPodFromAdmissionReview 的入参 admissionReview 提前检查有效性
 func getPodFromAdmissionReview(admissionReview *admissionv1.AdmissionReview) (*corev1.Pod, bool) {
 	if admissionReview == nil || admissionReview.Request == nil {
-		klog.Warningf("invalid admissionReview: %v", admissionReview)
+		klog.Warningf("[Webhook] invalid admissionReview: %v", admissionReview)
 		return nil, false
 	}
 	admissionRequest := admissionReview.Request
 	pod := corev1.Pod{}
 	if err := json.Unmarshal(admissionRequest.Object.Raw, &pod); err != nil {
-		klog.Warningf("failed to unmarshal admissionRequest.Object.Raw to pod, error: %v, admissionRequest: %v", err, admissionRequest)
+		klog.Warningf("[Webhook] failed to unmarshal admissionRequest.Object.Raw to pod, error: %v, admissionRequest: %v", err, admissionRequest)
 		return nil, false
 	}
 	return &pod, true

--- a/internal/ctrl/httpsvr.go
+++ b/internal/ctrl/httpsvr.go
@@ -41,9 +41,9 @@ func (s *HttpsServer) ServeTLS(ctx context.Context, stopCh chan struct{}) {
 	go func() {
 		select {
 		case <-ctx.Done(): // 监听到上下文取消信号，开始优雅关闭服务器
-			klog.Info("context canceled, shutting down HTTPS server...")
+			klog.Info("[HttpsServer] context canceled, shutting down...")
 		case <-stopCh: // 监听到外部停止信号，开始优雅关闭服务器
-			klog.Info("stop signal received, shutting down HTTPS server...")
+			klog.Info("[HttpsServer] stop signal received, shutting down...")
 		}
 		stopCtx, cancel := context.WithTimeout(context.Background(), s.gracefulShutdownTimeout)
 		defer cancel()
@@ -51,17 +51,17 @@ func (s *HttpsServer) ServeTLS(ctx context.Context, stopCh chan struct{}) {
 		if err != nil {
 			// 如果优雅关闭失败，强制关闭服务器
 			if closeErr := httpSvr.Close(); closeErr != nil {
-				klog.Errorf("Failed to force close HTTPS server, error: %v", closeErr)
+				klog.Errorf("[HttpsServer] failed to force close: %v", closeErr)
 				return
 			}
-			klog.Errorf("HTTPS server graceful shutdown failed: %v", err)
+			klog.Errorf("[HttpsServer] graceful shutdown failed: %v", err)
 			return
 		}
-		klog.Info("HTTPS server graceful shutdown completed")
+		klog.Info("[HttpsServer] graceful shutdown completed")
 	}()
 
 	if err := httpSvr.ServeTLS(listener, s.tlsCertFile, s.tlsKeyFile); err != nil && err != http.ErrServerClosed {
-		klog.Errorf("Failed to start HTTPS server, error: %v", err)
+		klog.Errorf("[HttpsServer] failed to start: %v", err)
 	}
-	klog.Info("HTTPS server stopped")
+	klog.Info("[HttpsServer] stopped")
 }

--- a/internal/ctrl/reconciler/container_reconciler.go
+++ b/internal/ctrl/reconciler/container_reconciler.go
@@ -62,19 +62,19 @@ func (r *CustomResourcesReconciler) listStatefulSets(nameSpace string) (*appsv1.
 func (r *CustomResourcesReconciler) OnAdded(obj any) {
 	customContainer := resources.ParseContainer(obj)
 	if customContainer == nil {
-		klog.Warningf("added object is not a valid container, skipping: %v", obj)
+		klog.Warningf("[Reconciler] added object is not a valid container, skipping: %v", obj)
 		return
 	}
 	coreContainer := customContainer.ToCoreV1Container()
 	_, ok := r.kv.Add(coreContainer.Name, &coreContainer)
-	klog.Infof("container %s added to cache, exist before: %v", coreContainer.Name, !ok)
+	klog.Infof("[Reconciler] container %s added to cache, already existed: %v", coreContainer.Name, !ok)
 }
 
 // TODO：如何面对 containerName 变化的情况？极低价值
 func (r *CustomResourcesReconciler) OnUpdated(oldObj, newObj any) {
 	newContainer := resources.ParseContainer(newObj)
 	if newContainer == nil {
-		klog.Errorf("updated object is not a valid container, skipping: %v", newObj)
+		klog.Warningf("[Reconciler] updated object is not a valid container, skipping: %v", newObj)
 		return
 	}
 	coreContainer := newContainer.ToCoreV1Container()
@@ -88,7 +88,7 @@ func (r *CustomResourcesReconciler) OnUpdated(oldObj, newObj any) {
 		for _, dep := range deployments.Items {
 			newDeploy := deployWithContainerUpdated(&dep, coreContainer)
 			if err := updateDeployment(r.kubeClient, newDeploy); err != nil {
-				klog.Errorf("update deployment %s/%s failed: %v", dep.Namespace, dep.Name, err)
+				klog.Errorf("[Reconciler] update deployment %s/%s failed: %v", dep.Namespace, dep.Name, err)
 			}
 		}
 	}
@@ -98,7 +98,7 @@ func (r *CustomResourcesReconciler) OnUpdated(oldObj, newObj any) {
 		for _, sts := range statefulSets.Items {
 			newSts := statefulsetWithContainerUpdated(&sts, coreContainer)
 			if err := updateStatefulSet(r.kubeClient, newSts); err != nil {
-				klog.Errorf("update statefulset %s/%s failed: %v", sts.Namespace, sts.Name, err)
+				klog.Errorf("[Reconciler] update statefulset %s/%s failed: %v", sts.Namespace, sts.Name, err)
 			}
 		}
 	}
@@ -107,7 +107,7 @@ func (r *CustomResourcesReconciler) OnUpdated(oldObj, newObj any) {
 func (r *CustomResourcesReconciler) OnDeleted(obj any) {
 	container := resources.ParseContainer(obj)
 	if container == nil {
-		klog.Errorf("deleted object is not a valid container, skipping: %v", obj)
+		klog.Warningf("[Reconciler] deleted object is not a valid container, skipping: %v", obj)
 		return
 	}
 	coreContainer := container.ToCoreV1Container()
@@ -122,7 +122,7 @@ func (r *CustomResourcesReconciler) OnDeleted(obj any) {
 		for _, dep := range deployments.Items {
 			newDeploy := deployWithContainerRemoved(&dep, containerName)
 			if err := updateDeployment(r.kubeClient, newDeploy); err != nil {
-				klog.Errorf("update deployment %s/%s failed while removing container %q: %v", dep.Namespace, dep.Name, containerName, err)
+				klog.Errorf("[Reconciler] update deployment %s/%s failed while removing container %q: %v", dep.Namespace, dep.Name, containerName, err)
 			}
 		}
 	}
@@ -132,7 +132,7 @@ func (r *CustomResourcesReconciler) OnDeleted(obj any) {
 		for _, sts := range statefulSets.Items {
 			newSts := statefulsetWithContainerRemoved(&sts, containerName)
 			if err := updateStatefulSet(r.kubeClient, newSts); err != nil {
-				klog.Errorf("update statefulset %s/%s failed while removing container %q: %v", sts.Namespace, sts.Name, containerName, err)
+				klog.Errorf("[Reconciler] update statefulset %s/%s failed while removing container %q: %v", sts.Namespace, sts.Name, containerName, err)
 			}
 		}
 	}

--- a/internal/ctrl/reconciler/container_removed.go
+++ b/internal/ctrl/reconciler/container_removed.go
@@ -18,7 +18,7 @@ func containersWithOneRemoved(containers []corev1.Container, containerName strin
 
 func deployWithContainerRemoved(deploy *appsv1.Deployment, containerName string) *appsv1.Deployment {
 	if deploy == nil {
-		klog.Warningf("deploy is nil, cannot remove container %s", containerName)
+		klog.Warningf("[Reconciler] deploy is nil, cannot remove container %s", containerName)
 		return &appsv1.Deployment{}
 	}
 	spec := &deploy.Spec.Template.Spec
@@ -29,7 +29,7 @@ func deployWithContainerRemoved(deploy *appsv1.Deployment, containerName string)
 
 func statefulsetWithContainerRemoved(sts *appsv1.StatefulSet, containerName string) *appsv1.StatefulSet {
 	if sts == nil {
-		klog.Warningf("statefulset is nil, cannot remove container %s", containerName)
+		klog.Warningf("[Reconciler] statefulset is nil, cannot remove container %s", containerName)
 		return &appsv1.StatefulSet{}
 	}
 	spec := &sts.Spec.Template.Spec

--- a/internal/ctrl/reconciler/container_updated.go
+++ b/internal/ctrl/reconciler/container_updated.go
@@ -24,7 +24,7 @@ func containersWithOneUpdated(containers []corev1.Container, newContainer corev1
 
 func deployWithContainerUpdated(deploy *appsv1.Deployment, newContainer corev1.Container) *appsv1.Deployment {
 	if deploy == nil {
-		klog.Warningf("deploy is nil, cannot update container %s", newContainer.Name)
+		klog.Warningf("[Reconciler] deploy is nil, cannot update container %s", newContainer.Name)
 		return deploy
 	}
 	spec := &deploy.Spec.Template.Spec
@@ -35,7 +35,7 @@ func deployWithContainerUpdated(deploy *appsv1.Deployment, newContainer corev1.C
 
 func statefulsetWithContainerUpdated(sts *appsv1.StatefulSet, newContainer corev1.Container) *appsv1.StatefulSet {
 	if sts == nil {
-		klog.Warningf("statefulset is nil, cannot update container %s", newContainer.Name)
+		klog.Warningf("[Reconciler] statefulset is nil, cannot update container %s", newContainer.Name)
 		return sts
 	}
 	spec := &sts.Spec.Template.Spec

--- a/internal/ctrl/shutdown.go
+++ b/internal/ctrl/shutdown.go
@@ -29,18 +29,18 @@ func addressValidate(address string) (string, bool) {
 func Shutdown(opt *ShutdownOptions) {
 	address, valid := addressValidate(opt.address)
 	if !valid {
-		klog.Errorf("Invalid address: %s", opt.address)
+		klog.Errorf("[Shutdown] invalid address: %s", opt.address)
 		return
 	}
 
 	caPem, err := os.ReadFile(opt.certFile)
 	if err != nil {
-		klog.Errorf("Failed to read CA cert: %v", err)
+		klog.Errorf("[Shutdown] failed to read CA cert: %v", err)
 		return
 	}
 	rootCAs := x509.NewCertPool()
 	if !rootCAs.AppendCertsFromPEM(caPem) {
-		klog.Errorf("Failed to append CA cert to cert pool")
+		klog.Errorf("[Shutdown] failed to append CA cert to cert pool")
 		return
 	}
 	host, _, _ := net.SplitHostPort(address)
@@ -57,13 +57,13 @@ func Shutdown(opt *ShutdownOptions) {
 
 	resp, err := client.Post("https://"+address+"/preStop", "application/json", nil)
 	if err != nil {
-		klog.Errorf("Failed to send preStop request: %v", err)
+		klog.Errorf("[Shutdown] failed to send preStop request: %v", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		klog.Errorf("Expected status code 200, got %d", resp.StatusCode)
+		klog.Errorf("[Shutdown] expected status code 200, got %d", resp.StatusCode)
 		return
 	}
 }

--- a/internal/ctrl/startup.go
+++ b/internal/ctrl/startup.go
@@ -98,7 +98,7 @@ func StartUp(rootContext context.Context, opts *StartUpOptions) {
 	go func() {
 		defer wg.Done()
 		if err := grpcSvr.ListenAndServe(ctx, opts.GrpcOptions()); err != nil {
-			klog.Errorf("Failed to start gRPC server: %v", err)
+			klog.Errorf("[GrpcServer] failed to start: %v", err)
 		}
 	}()
 

--- a/internal/ctrl/utils/sidecar.go
+++ b/internal/ctrl/utils/sidecar.go
@@ -24,32 +24,27 @@ func NewSidecar(name, subService string) *Sidecar {
 
 // Informer 把 obj 写到 channel 中，阻塞则跳过
 func (s *Sidecar) Informer(opType mesh.OpType, obj any) {
-	klog.Errorf("[Sidecar][Informer] Start Informer")
 	if obj == nil {
-		// Handle nil object case
-		klog.Warningf("[Sidecar][Informer] Received nil object for service %s in sidecar %s, skipping\n", s.SubServiceName, s.Name)
+		klog.Warningf("[Sidecar][Informer] received nil object for service %s in sidecar %s, skipping", s.SubServiceName, s.Name)
 		return
 	}
 	endpointSlice, ok := obj.(*discoveryv1.EndpointSlice)
 	if !ok {
-		// Handle type assertion failure
-		klog.Errorf("[Sidecar][Informer] Failed to cast object to EndpointSlice for service %s in sidecar %s, skipping\n", s.SubServiceName, s.Name)
+		klog.Warningf("[Sidecar][Informer] failed to cast object to EndpointSlice for service %s in sidecar %s, skipping", s.SubServiceName, s.Name)
 		return
 	}
 	svcName := endpointSlice.Labels["kubernetes.io/service-name"]
 	if svcName != s.SubServiceName {
-		// Not interested in this service
-		klog.Infof("[Sidecar][Informer] Received update for service %s which does not match subscribed service %s in sidecar %s, skipping\n", svcName, s.SubServiceName, s.Name)
+		klog.V(4).Infof("[Sidecar][Informer] received update for service %s which does not match subscribed service %s in sidecar %s, skipping", svcName, s.SubServiceName, s.Name)
 		return
 	}
 	protoMsg := newClientSubscriptionEvent(opType, endpointSlice)
 	select {
 	case s.receiver <- protoMsg:
-		klog.Infof("[Sidecar][Informer] Sent update for service %s to sidecar %s\n", svcName, s.Name)
+		klog.Infof("[Sidecar][Informer] sent update for service %s to sidecar %s", svcName, s.Name)
 	default:
-		klog.Warningf("[Sidecar][Informer] Skipping update for service %s to sidecar %s due to full channel\n", svcName, s.Name)
+		klog.Warningf("[Sidecar][Informer] skipping update for service %s to sidecar %s: channel full", svcName, s.Name)
 	}
-	klog.Errorf("[Sidecar][Informer] Finished Informer")
 }
 
 // Receiver 返回一个只读的 channel，供 sidecar 监听


### PR DESCRIPTION
**级别修改**
文件|行为|修改
:---|:---|:---
`sidecar.go`|`Start/Finished Informer`|`Errorf` → 直接删除（纯调试迹，无业务价值）
`sidecar.go`|类型断言失败|`Errorf` → `Warningf`（输入校验失败，非系统错误）
`sidecar.go`|服务名不匹配（跳过）|`Infof` → `V(4).Infof`（per-call 噪音）
`container_reconciler.go`|`OnUpdated`/`OnDeleted` 对象校验失败|`Errorf` → `Warningf`
`httpsvr.go`|收到 stop 信号|`Warning` → `Info`（正常关闭流程，非异常）
`grpcserver/server.go`|成功发送 event|`Infof` → `V(4).Infof`（per-stream 噪音）
·http_transport.go`|所有 per-request 路径日志|`Infof` → `V(4).Infof`（每个请求都打 Info 过于嘈杂）
`stgsvr/handlers.go`|service not found|`Errorf` → `Warningf`（业务未找到，非系统错误）

**格式修复**
* 去除所有 klog 格式串中手动添加的 `\n`（klog 自动换行）
* `rpcclient/client.go`：`klog.Error(..., err)` 拼接风格 → `klog.Errorf(..., %v, err)`

**可视化统一（`[Module]` 前缀）**
* 补全 `[Reconciler]`、`[Webhook]`、`[HttpsServer]`、`[Shutdown]`、`[GrpcServer]`、`[Signal]`、`[RpcClient]`、`[Proxy]`、`[StgSvr]` 前缀，已有前缀的（如 `[GrpcServer][Subscribe]`、`[Sidecar][Informer]`）保持不变