### PR TITLE
对瞬时失败（如 API 限流）vs 永久失败（如 CRD 不存在）分类处理

### DIFF
--- a/internal/ctrl/worker/crd_handlers.go
+++ b/internal/ctrl/worker/crd_handlers.go
@@ -45,7 +45,7 @@ func (h *CRDHandlers) OnUpdated(_, newObj any) {
 	}
 	coreContainer := container.ToCoreV1Container()
 	if _, ok := h.cache.Update(coreContainer.Name, &coreContainer); !ok {
-		klog.Infof("[CRDHandlers] container %s not in cache, skipping update enqueue", coreContainer.Name)
+		klog.Warningf("[CRDHandlers] container %s not in cache, skipping update enqueue", coreContainer.Name)
 		return
 	}
 	h.enqueue(&CRDWorkerEvent{
@@ -63,7 +63,7 @@ func (h *CRDHandlers) OnDeleted(obj any) {
 	}
 	coreContainer := container.ToCoreV1Container()
 	if _, ok := h.cache.Delete(coreContainer.Name); !ok {
-		klog.Infof("[CRDHandlers] container %s not in cache, skipping delete enqueue", coreContainer.Name)
+		klog.Warningf("[CRDHandlers] container %s not in cache, skipping delete enqueue", coreContainer.Name)
 		return
 	}
 	h.enqueue(&CRDWorkerEvent{

--- a/internal/ctrl/worker/crd_worker.go
+++ b/internal/ctrl/worker/crd_worker.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -88,12 +87,15 @@ func (w *CRDWorker) process(key string) {
 	}
 
 	if err := w.processEvent(event); err != nil {
-		if w.shouldRetry(key) {
+		if !errors.Is(err, RetryableError) {
+			klog.Errorf("[CRDWorker] dropping %q, non-retryable error: %v", key, err)
+		} else if w.shouldRetry(key) {
 			klog.Errorf("[CRDWorker] error processing %q, enqueue with exponential backoff: %v", key, err)
 			w.queue.AddRateLimited(key)
 			return
+		} else {
+			klog.Errorf("[CRDWorker] dropping %q after %d retries: %v", key, w.maxRetries, err)
 		}
-		klog.Errorf("[CRDWorker] dropping %q after %d retries: %v", key, w.maxRetries, err)
 	}
 	w.queue.Forget(key)
 }
@@ -132,23 +134,23 @@ func (w *CRDWorker) reconcileUpdate(containerName, namespace string) error {
 
 	deployments, err := w.listDeployments(namespace)
 	if err != nil {
-		return fmt.Errorf("list deployments in namespace %s: %w", namespace, err)
+		return NewProcessError(true, "list deployments in namespace %s: %s", namespace, err.Error())
 	}
 	for i := range deployments.Items {
 		updated := deployWithContainerUpdated(&deployments.Items[i], *container)
 		if err := w.updateDeployment(updated); err != nil {
-			errs = append(errs, fmt.Errorf("update deployment %s/%s: %w", updated.Namespace, updated.Name, err))
+			errs = append(errs, NewProcessError(true, "update deployment %s/%s: %s", updated.Namespace, updated.Name, err.Error()))
 		}
 	}
 
 	statefulSets, err := w.listStatefulSets(namespace)
 	if err != nil {
-		return fmt.Errorf("list statefulsets in namespace %s: %w", namespace, err)
+		return NewProcessError(true, "list statefulsets in namespace %s: %s", namespace, err.Error())
 	}
 	for i := range statefulSets.Items {
 		updated := statefulsetWithContainerUpdated(&statefulSets.Items[i], *container)
 		if err := w.updateStatefulSet(updated); err != nil {
-			errs = append(errs, fmt.Errorf("update statefulset %s/%s: %w", updated.Namespace, updated.Name, err))
+			errs = append(errs, NewProcessError(true, "update statefulset %s/%s: %s", updated.Namespace, updated.Name, err.Error()))
 		}
 	}
 
@@ -160,23 +162,23 @@ func (w *CRDWorker) reconcileDelete(containerName, namespace string) error {
 
 	deployments, err := w.listDeployments(namespace)
 	if err != nil {
-		return fmt.Errorf("list deployments in namespace %s: %w", namespace, err)
+		return NewProcessError(true, "list deployments in namespace %s: %s", namespace, err.Error())
 	}
 	for i := range deployments.Items {
 		updated := deployWithContainerRemoved(&deployments.Items[i], containerName)
 		if err := w.updateDeployment(updated); err != nil {
-			errs = append(errs, fmt.Errorf("update deployment %s/%s: %w", updated.Namespace, updated.Name, err))
+			errs = append(errs, NewProcessError(true, "update deployment %s/%s: %s", updated.Namespace, updated.Name, err.Error()))
 		}
 	}
 
 	statefulSets, err := w.listStatefulSets(namespace)
 	if err != nil {
-		return fmt.Errorf("list statefulsets in namespace %s: %w", namespace, err)
+		return NewProcessError(true, "list statefulsets in namespace %s: %s", namespace, err.Error())
 	}
 	for i := range statefulSets.Items {
 		updated := statefulsetWithContainerRemoved(&statefulSets.Items[i], containerName)
 		if err := w.updateStatefulSet(updated); err != nil {
-			errs = append(errs, fmt.Errorf("update statefulset %s/%s: %w", updated.Namespace, updated.Name, err))
+			errs = append(errs, NewProcessError(true, "update statefulset %s/%s: %s", updated.Namespace, updated.Name, err.Error()))
 		}
 	}
 

--- a/internal/ctrl/worker/crd_worker_test.go
+++ b/internal/ctrl/worker/crd_worker_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -376,6 +377,101 @@ func TestCRDWorker_ProcessEvent_Delete(t *testing.T) {
 	}
 	if len(updated.Spec.Template.Spec.Containers) != 1 {
 		t.Errorf("expected 1 container remaining, got %d", len(updated.Spec.Template.Spec.Containers))
+	}
+}
+
+// --- TestCRDWorker_ReconcileUpdate/Delete error classification ---
+
+func TestCRDWorker_ReconcileUpdate_ListFailure_IsRetryable(t *testing.T) {
+	const namespace = "default"
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Fake.PrependReactor("list", "deployments",
+		func(_ k8sTesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("simulated list error")
+		},
+	)
+
+	c := cache.NewGeneralCache[*corev1.Container]()
+	c.Add("sidecar", &corev1.Container{Name: "sidecar", Image: "nginx:v2"})
+	w := newTestWorker(c, fakeClient)
+
+	err := w.reconcileUpdate("sidecar", namespace)
+	if err == nil {
+		t.Fatal("expected error when listing deployments fails")
+	}
+	if !errors.Is(err, RetryableError) {
+		t.Errorf("expected list failure to be classified as retryable, got: %v", err)
+	}
+}
+
+func TestCRDWorker_ReconcileUpdate_PartialUpdateFailure_AggregatesAsRetryable(t *testing.T) {
+	// Two Deployments and two StatefulSets; only one Update call of each fails.
+	// reconcileUpdate should still return an error, and errors.Is(err, RetryableError)
+	// should be true because at least one of the joined errors is retryable.
+	const (
+		namespace     = "default"
+		containerName = "sidecar"
+		label         = "mesh-inject"
+	)
+
+	depOK := makeDeployment("dep-ok", namespace, label, corev1.Container{Name: containerName, Image: "nginx:v1"})
+	depFail := makeDeployment("dep-fail", namespace, label, corev1.Container{Name: containerName, Image: "nginx:v1"})
+	fakeClient := fake.NewSimpleClientset(depOK, depFail)
+
+	fakeClient.Fake.PrependReactor("update", "deployments",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			updateAction := action.(k8sTesting.UpdateAction)
+			dep := updateAction.GetObject().(*appsv1.Deployment)
+			if dep.Name == "dep-fail" {
+				return true, nil, fmt.Errorf("simulated update error")
+			}
+			return false, nil, nil
+		},
+	)
+
+	c := cache.NewGeneralCache[*corev1.Container]()
+	c.Add(containerName, &corev1.Container{Name: containerName, Image: "nginx:v2"})
+	w := newTestWorker(c, fakeClient)
+
+	err := w.reconcileUpdate(containerName, namespace)
+	if err == nil {
+		t.Fatal("expected aggregated error from partial update failure")
+	}
+	if !errors.Is(err, RetryableError) {
+		t.Errorf("expected aggregated error to be retryable, got: %v", err)
+	}
+
+	ctx := context.Background()
+	ok, getErr := fakeClient.AppsV1().Deployments(namespace).Get(ctx, "dep-ok", metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("failed to get dep-ok: %v", getErr)
+	}
+	if ok.Spec.Template.Spec.Containers[0].Image != "nginx:v2" {
+		t.Errorf("expected dep-ok to be updated despite dep-fail failing, got image %q",
+			ok.Spec.Template.Spec.Containers[0].Image)
+	}
+}
+
+func TestCRDWorker_ReconcileDelete_ListFailure_IsRetryable(t *testing.T) {
+	const namespace = "default"
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Fake.PrependReactor("list", "statefulsets",
+		func(_ k8sTesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("simulated list error")
+		},
+	)
+
+	c := cache.NewGeneralCache[*corev1.Container]()
+	w := newTestWorker(c, fakeClient)
+
+	err := w.reconcileDelete("sidecar", namespace)
+	if err == nil {
+		t.Fatal("expected error when listing statefulsets fails")
+	}
+	if !errors.Is(err, RetryableError) {
+		t.Errorf("expected list failure to be classified as retryable, got: %v", err)
 	}
 }
 

--- a/internal/ctrl/worker/errors.go
+++ b/internal/ctrl/worker/errors.go
@@ -1,0 +1,36 @@
+package worker
+
+import (
+	"fmt"
+)
+
+type ProcessError struct {
+	message   string
+	retryable bool
+}
+
+func (re *ProcessError) Error() string {
+	return re.message
+}
+
+func (re *ProcessError) Retryable() bool {
+	return re.retryable
+}
+
+func (re *ProcessError) Is(err error) bool {
+	re2, ok := err.(*ProcessError)
+	if !ok {
+		return false
+	}
+	return re.retryable == re2.retryable
+}
+
+var RetryableError = &ProcessError{retryable: true}
+var UnretryableError = &ProcessError{retryable: false}
+
+func NewProcessError(retryable bool, format string, a ...any) *ProcessError {
+	return &ProcessError{
+		message:   fmt.Sprintf(format, a...),
+		retryable: retryable,
+	}
+}

--- a/internal/ctrl/worker/errors_test.go
+++ b/internal/ctrl/worker/errors_test.go
@@ -1,0 +1,94 @@
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNewProcessError(t *testing.T) {
+	tests := []struct {
+		name      string
+		retryable bool
+	}{
+		{name: "retryable", retryable: true},
+		{name: "non-retryable", retryable: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := NewProcessError(tc.retryable, "update %s/%s: %s", "default", "my-dep", "boom")
+
+			if got, want := err.Error(), "update default/my-dep: boom"; got != want {
+				t.Errorf("Error() = %q, want %q", got, want)
+			}
+			if err.Retryable() != tc.retryable {
+				t.Errorf("Retryable() = %v, want %v", err.Retryable(), tc.retryable)
+			}
+		})
+	}
+}
+
+func TestProcessError_Is(t *testing.T) {
+	retryableA := NewProcessError(true, "error A")
+	retryableB := NewProcessError(true, "error B")
+	permanentA := NewProcessError(false, "error C")
+
+	// Is matches solely on the retryable flag, regardless of message.
+	if !errors.Is(retryableA, retryableB) {
+		t.Error("expected two retryable ProcessErrors with different messages to match via errors.Is")
+	}
+	if errors.Is(retryableA, permanentA) {
+		t.Error("expected retryable and non-retryable ProcessErrors not to match via errors.Is")
+	}
+
+	// Sentinels behave as the retryable-flag class representatives.
+	if !errors.Is(retryableA, RetryableError) {
+		t.Error("expected retryable ProcessError to match RetryableError sentinel")
+	}
+	if errors.Is(retryableA, UnretryableError) {
+		t.Error("expected retryable ProcessError not to match UnretryableError sentinel")
+	}
+	if !errors.Is(permanentA, UnretryableError) {
+		t.Error("expected non-retryable ProcessError to match UnretryableError sentinel")
+	}
+	if errors.Is(permanentA, RetryableError) {
+		t.Error("expected non-retryable ProcessError not to match RetryableError sentinel")
+	}
+}
+
+func TestProcessError_Is_NonProcessError(t *testing.T) {
+	err := NewProcessError(true, "boom")
+	other := fmt.Errorf("some other error")
+
+	if errors.Is(err, other) {
+		t.Error("expected ProcessError not to match a non-ProcessError via errors.Is")
+	}
+	if errors.Is(other, RetryableError) {
+		t.Error("expected a plain error not to match the RetryableError sentinel")
+	}
+}
+
+func TestErrorsIs_JoinedErrors_RetryableIfAnyRetryable(t *testing.T) {
+	// errors.Join + errors.Is: a batch is treated as retryable if ANY sub-error is retryable,
+	// which is exactly the semantics CRDWorker.process relies on to decide whether to requeue.
+	joined := errors.Join(
+		NewProcessError(false, "permanent failure on item 1"),
+		NewProcessError(true, "transient failure on item 2"),
+	)
+
+	if !errors.Is(joined, RetryableError) {
+		t.Error("expected joined error containing a retryable sub-error to match RetryableError")
+	}
+
+	allPermanent := errors.Join(
+		NewProcessError(false, "permanent failure on item 1"),
+		NewProcessError(false, "permanent failure on item 2"),
+	)
+	if errors.Is(allPermanent, RetryableError) {
+		t.Error("expected joined error with only non-retryable sub-errors not to match RetryableError")
+	}
+	if !errors.Is(allPermanent, UnretryableError) {
+		t.Error("expected joined error with only non-retryable sub-errors to match UnretryableError")
+	}
+}


### PR DESCRIPTION
Fixes #55